### PR TITLE
Preliminary fix for #17

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,12 +563,18 @@ fn apply_mask(
 
             apply_mask(mask.mask.as_ref(), mask.rect, pdf_bbox, ctx);
 
-            ctx.pending_groups.insert(mask.id.clone(), PendingGroup {
-                reference,
-                bbox,
-                matrix,
-                initial_mask: mask.mask.clone(),
-            });
+            let context_transform = ctx.c.get_transform();
+
+            ctx.pending_groups.insert(
+                mask.id.clone(),
+                PendingGroup {
+                    reference,
+                    bbox,
+                    matrix,
+                    transform: context_transform,
+                    initial_mask: mask.mask.clone(),
+                },
+            );
 
             Some(reference)
         } else {

--- a/src/render.rs
+++ b/src/render.rs
@@ -539,7 +539,6 @@ impl Render for usvg::Group {
         content.save_state();
 
         apply_clip_path(self.clip_path.as_ref(), content, ctx);
-        ctx.c.set_transform(old);
 
         if let Some(reference) = apply_mask(self.mask.as_ref(), bbox, pdf_bbox, ctx) {
             let num = ctx.alloc_gs();
@@ -553,6 +552,8 @@ impl Render for usvg::Group {
             ctx.pending_graphics
                 .push(PendingGS::fill_opacity(self.opacity.value() as f32, num));
         }
+
+        ctx.c.set_transform(old);
 
         content.x_object(Name(name.as_bytes()));
         content.restore_state();

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -171,7 +171,13 @@ impl CoordToPdf {
         old
     }
 
-    pub fn set_transform(&mut self, transform: Transform) {
+    pub fn set_transform(&mut self, transform: Transform) -> Transform {
+        let old = self.transform;
         self.transform = transform;
+        old
+    }
+
+    pub fn get_transform(&self) -> Transform {
+        self.transform
     }
 }

--- a/tests/circle.svg
+++ b/tests/circle.svg
@@ -1,0 +1,10 @@
+<svg version="1.1" height="106" width="106" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g transform="translate(53, 53)">
+        <g id="circle" mask="url(#rect_mask)">
+            <circle r="43" fill="none" stroke="black" stroke-width="9"/>
+        </g>
+        <mask id="rect_mask">
+            <rect x="-60" y="-60" width="120" height="120" fill="white" />
+        </mask>
+    </g>
+</svg>

--- a/tests/rust_logo.svg
+++ b/tests/rust_logo.svg
@@ -1,0 +1,57 @@
+<svg version="1.1" height="106" width="106" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="logo" transform="translate(53, 53)">
+        <path id="r" transform="translate(0.5, 0.5)" stroke="black" stroke-width="1" stroke-linejoin="round" d="     M -9,-15 H 4 C 12,-15 12,-7 4,-7 H -9 Z     M -40,22 H 0 V 11 H -9 V 3 H 1 C 12,3 6,22 15,22 H 40     V 3 H 34 V 5 C 34,13 25,12 24,7 C 23,2 19,-2 18,-2 C 33,-10 24,-26 12,-26 H -35     V -15 H -25 V 11 H -40 Z"/>
+        <g id="gear" mask="url(#holes)">
+            <circle r="43" fill="none" stroke="black" stroke-width="9"/>
+            <g id="cogs">
+                <polygon id="cog" stroke="black" stroke-width="3" stroke-linejoin="round" points="46,3 51,0 46,-3"/>
+                <use xlink:href="#cog" transform="rotate(11.25)"/>
+                <use xlink:href="#cog" transform="rotate(22.50)"/>
+                <use xlink:href="#cog" transform="rotate(33.75)"/>
+                <use xlink:href="#cog" transform="rotate(45.00)"/>
+                <use xlink:href="#cog" transform="rotate(56.25)"/>
+                <use xlink:href="#cog" transform="rotate(67.50)"/>
+                <use xlink:href="#cog" transform="rotate(78.75)"/>
+                <use xlink:href="#cog" transform="rotate(90.00)"/>
+                <use xlink:href="#cog" transform="rotate(101.25)"/>
+                <use xlink:href="#cog" transform="rotate(112.50)"/>
+                <use xlink:href="#cog" transform="rotate(123.75)"/>
+                <use xlink:href="#cog" transform="rotate(135.00)"/>
+                <use xlink:href="#cog" transform="rotate(146.25)"/>
+                <use xlink:href="#cog" transform="rotate(157.50)"/>
+                <use xlink:href="#cog" transform="rotate(168.75)"/>
+                <use xlink:href="#cog" transform="rotate(180.00)"/>
+                <use xlink:href="#cog" transform="rotate(191.25)"/>
+                <use xlink:href="#cog" transform="rotate(202.50)"/>
+                <use xlink:href="#cog" transform="rotate(213.75)"/>
+                <use xlink:href="#cog" transform="rotate(225.00)"/>
+                <use xlink:href="#cog" transform="rotate(236.25)"/>
+                <use xlink:href="#cog" transform="rotate(247.50)"/>
+                <use xlink:href="#cog" transform="rotate(258.75)"/>
+                <use xlink:href="#cog" transform="rotate(270.00)"/>
+                <use xlink:href="#cog" transform="rotate(281.25)"/>
+                <use xlink:href="#cog" transform="rotate(292.50)"/>
+                <use xlink:href="#cog" transform="rotate(303.75)"/>
+                <use xlink:href="#cog" transform="rotate(315.00)"/>
+                <use xlink:href="#cog" transform="rotate(326.25)"/>
+                <use xlink:href="#cog" transform="rotate(337.50)"/>
+                <use xlink:href="#cog" transform="rotate(348.75)"/>
+            </g>
+            <g id="mounts">
+                <polygon id="mount" stroke="black" stroke-width="6" stroke-linejoin="round" points="-7,-42 0,-35 7,-42"/>
+                <use xlink:href="#mount" transform="rotate(72)"/>
+                <use xlink:href="#mount" transform="rotate(144)"/>
+                <use xlink:href="#mount" transform="rotate(216)"/>
+                <use xlink:href="#mount" transform="rotate(288)"/>
+            </g>
+        </g>
+        <mask id="holes">
+            <rect x="-60" y="-60" width="120" height="120" fill="white"/>
+            <circle id="hole" cy="-40" r="3"/>
+            <use xlink:href="#hole" transform="rotate(72)"/>
+            <use xlink:href="#hole" transform="rotate(144)"/>
+            <use xlink:href="#hole" transform="rotate(216)"/>
+            <use xlink:href="#hole" transform="rotate(288)"/>
+        </mask>
+    </g>
+</svg>


### PR DESCRIPTION
I believe I found the culprits for why the rust logo in #17 doesn't render correctly.

So as far as I can see, there are two errors:

https://github.com/typst/svg2pdf/blob/b24680b27ee6047bcda512febdc6874d75b1e0b6/src/render.rs#L539-L548

In this part, the context is resetted before the `apply_mask` method is called, meaning that the context won't be considered in the method. I believe this is shouldn't be the case (and kind of my fault because I put it in the wrong place in my last PR)?

And secondly,

https://github.com/typst/svg2pdf/blob/b24680b27ee6047bcda512febdc6874d75b1e0b6/src/lib.rs#L279-L292

when calling the `write_masks`method, we pass the "original" context to it (which subsequentially is passed to the `content_stream` method) instead of the context of where the mask of the pending group was actually defined. Now I think this is a bit tricky to solve because currently, we are not storing the corresponding transformation anywhere, so we have no way of accessing it. What I did now as a "hotfix" is to store the transformation in the pending group when pushing it, but I'm not sure how good of an idea that is, so please just consider this PR as a draft for now. Also, I'm not sure if we have a similar issue with other pending objects (e.g. gradients) and I'm afraid I don't know enough about how gradients work in PDF, so I can't really judge it.

What do you think? @reknih 