### PR TITLE
Fix bug where scaling wasn't properly applied to stroke widths

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -173,7 +173,9 @@ fn render_path_partial(
 
     if stroke {
         if let Some(stroke) = &path.stroke {
-            content.set_line_width(ctx.c.px_to_pt(stroke.width.get()));
+            content.set_line_width(
+                ctx.c.px_to_pt(stroke.width.get() * ctx.c.compute_scale()),
+            );
 
             match stroke.linecap {
                 LineCap::Butt => content.set_line_cap(LineCapStyle::ButtCap),

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -184,6 +184,22 @@ impl CoordToPdf {
         self.transform.apply(point.0, point.1)
     }
 
+    /// Compute the scale (e.g. to adapt the stroke width).
+    pub fn compute_scale(&self) -> f64 {
+        let mut complete_transform = Transform::new_scale(self.factor_x, self.factor_y);
+        complete_transform.append(&self.transform);
+        let (x_scale, y_scale) = complete_transform.get_scale();
+
+        if x_scale.is_finite() && y_scale.is_finite() {
+            let scale = x_scale.max(y_scale);
+            if scale > 0.0 {
+                return scale;
+            }
+        }
+
+        1.0
+    }
+
     /// Set a pre-transformation, overriding the old one.
     pub fn concat_transform(&mut self, add_transform: Transform) -> Transform {
         let old = self.transform.clone();

--- a/tests/scaled_line_with_line_width.svg
+++ b/tests/scaled_line_with_line_width.svg
@@ -1,0 +1,6 @@
+<svg width="100" height="30" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <rect width="100" height="100" fill="white"></rect>
+    <g transform="scale(.1 .1)">
+        <line x1="0" x2="1000" y1="150" y2="150" stroke="#000" stroke-width="5"/>
+    </g>
+</svg>


### PR DESCRIPTION
Consider the following svg:
```svg
<svg width="100" height="30" version="1.1" xmlns="http://www.w3.org/2000/svg">
    <rect width="100" height="100" fill="white"></rect>
    <g transform="scale(.1 .1)">
        <line x1="0" x2="1000" y1="150" y2="150" stroke="#000" stroke-width="5"/>
    </g>
</svg>
```

It is currently rendered like this:
<img width="180" alt="image" src="https://github.com/typst/svg2pdf/assets/47084093/4d7d13b7-bff7-4850-a942-78e2048382e4">

Even though it should look more like this:
<img width="179" alt="image" src="https://github.com/typst/svg2pdf/assets/47084093/736a83a7-d4ef-4be8-bc5a-1e7233096b29">



The reason for this is that there was no scaling applied to the width of strokes. This PR should fix this. I looked into [how it's done in resvg](https://github.com/RazrFalcon/tiny-skia/blob/8496747c02d4398e320ed88c414954ff095a508e/path/src/stroker.rs#L288-L299) and tried to replicate this behavior in svg2pdf.