### PR TITLE
Disable default features for image dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ required-features = ["cli"]
 miniz_oxide = "0.7"
 pdf-writer = "0.8"
 usvg = { version = "0.35", default-features = false }
-image = { version = "0.24", features = ["jpeg", "png", "gif"], optional = true }
+image = { version = "0.24", default-features = false, features = ["jpeg", "png", "gif"], optional = true }
 termcolor = { version = "1", optional = true }
 clap = { version = "4.4.2", features = ["derive"], optional = true }
 fontdb = { version = "0.14", optional= true }


### PR DESCRIPTION
The `image` crate supports more image formats than strictly necessary.
This PR removes support for them.