### PR TITLE
Allow writing into chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,11 +912,11 @@ dependencies = [
 [[package]]
 name = "pdf-writer"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d77bc47c8968aa63f86a7e6693e270a6cbd1e3b784c364f1711a0ddecc71447"
+source = "git+https://github.com/typst/pdf-writer?branch=chunks#1b03c04c9bc0e91bc956a7b30972cdc798cb65f8"
 dependencies = [
  "bitflags 1.3.2",
  "itoa",
+ "memchr",
  "ryu",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,8 +911,9 @@ dependencies = [
 
 [[package]]
 name = "pdf-writer"
-version = "0.8.1"
-source = "git+https://github.com/typst/pdf-writer?branch=chunks#1b03c04c9bc0e91bc956a7b30972cdc798cb65f8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b651409cd03bf702052d7491f08d27fbd6b25f96dc8b9b873ada7d0b3342b8d"
 dependencies = [
  "bitflags 1.3.2",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ required-features = ["cli"]
 
 [dependencies]
 miniz_oxide = "0.7"
-pdf-writer = "0.8"
+pdf-writer = "0.9"
 usvg = { version = "0.35", default-features = false }
 image = { version = "0.24", default-features = false, features = ["jpeg", "png", "gif"], optional = true }
 termcolor = { version = "1", optional = true }
@@ -45,6 +45,3 @@ fontdb = { version = "0.14", optional= true }
 
 [dev-dependencies]
 usvg = { version = "0.35.0" }
-
-[patch.crates-io]
-pdf-writer = { git = "https://github.com/typst/pdf-writer", branch = "chunks" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,6 @@ fontdb = { version = "0.14", optional= true }
 
 [dev-dependencies]
 usvg = { version = "0.35.0" }
+
+[patch.crates-io]
+pdf-writer = { git = "https://github.com/typst/pdf-writer", branch = "chunks" }

--- a/src/render/mask.rs
+++ b/src/render/mask.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use pdf_writer::{Content, Filter, Finish, PdfWriter};
+use pdf_writer::{Chunk, Content, Filter, Finish};
 use usvg::{Mask, Node, NodeKind, Transform, Units};
 
 use super::group;
@@ -13,11 +13,11 @@ use crate::util::helper::{
 pub fn render(
     node: &Node,
     mask: Rc<Mask>,
-    writer: &mut PdfWriter,
+    chunk: &mut Chunk,
     content: &mut Content,
     ctx: &mut Context,
 ) {
-    content.set_parameters(create(node, mask, writer, ctx).to_pdf_name());
+    content.set_parameters(create(node, mask, chunk, ctx).to_pdf_name());
 }
 
 /// Turn a mask into an graphics state object. Returns the name (= the name in the `Resources` dictionary) of
@@ -25,7 +25,7 @@ pub fn render(
 pub fn create(
     parent: &Node,
     mask: Rc<Mask>,
-    writer: &mut PdfWriter,
+    chunk: &mut Chunk,
     ctx: &mut Context,
 ) -> Rc<String> {
     let x_ref = ctx.alloc_ref();
@@ -35,7 +35,7 @@ pub fn create(
     content.save_state();
 
     if let Some(recursive_mask) = &mask.mask {
-        render(parent, recursive_mask.clone(), writer, &mut content, ctx);
+        render(parent, recursive_mask.clone(), chunk, &mut content, ctx);
     }
 
     let parent_svg_bbox = plain_bbox(parent, true);
@@ -62,7 +62,7 @@ pub fn create(
             group::render(
                 &mask.root,
                 group,
-                writer,
+                chunk,
                 &mut content,
                 ctx,
                 accumulated_transform,
@@ -74,7 +74,7 @@ pub fn create(
     content.restore_state();
     let content_stream = ctx.finish_content(content);
 
-    let mut x_object = writer.form_xobject(x_ref, &content_stream);
+    let mut x_object = chunk.form_xobject(x_ref, &content_stream);
     ctx.deferrer.pop(&mut x_object.resources());
 
     if ctx.options.compress {
@@ -93,7 +93,7 @@ pub fn create(
     x_object.finish();
 
     let gs_ref = ctx.alloc_ref();
-    let mut gs = writer.ext_graphics(gs_ref);
+    let mut gs = chunk.ext_graphics(gs_ref);
     gs.soft_mask().subtype(mask.kind.to_pdf_mask_type()).group(x_ref);
 
     ctx.deferrer.add_graphics_state(gs_ref)

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,4 +1,4 @@
-use pdf_writer::{Content, PdfWriter};
+use pdf_writer::{Chunk, Content};
 use usvg::{Node, NodeKind, Transform, Tree};
 
 use crate::util::context::Context;
@@ -17,7 +17,7 @@ pub mod pattern;
 /// right bounding boxes.
 pub fn tree_to_stream(
     tree: &Tree,
-    writer: &mut PdfWriter,
+    chunk: &mut Chunk,
     content: &mut Content,
     ctx: &mut Context,
     initial_transform: Transform,
@@ -26,14 +26,14 @@ pub fn tree_to_stream(
     let initial_transform = initial_transform.pre_concat(ctx.get_view_box_transform());
     content.transform(initial_transform.to_pdf_transform());
 
-    tree.root.render(writer, content, ctx, initial_transform);
+    tree.root.render(chunk, content, ctx, initial_transform);
     content.restore_state();
 }
 
 trait Render {
     fn render(
         &self,
-        writer: &mut PdfWriter,
+        chunk: &mut Chunk,
         content: &mut Content,
         ctx: &mut Context,
         accumulated_transform: Transform,
@@ -43,20 +43,20 @@ trait Render {
 impl Render for Node {
     fn render(
         &self,
-        writer: &mut PdfWriter,
+        chunk: &mut Chunk,
         content: &mut Content,
         ctx: &mut Context,
         accumulated_transform: Transform,
     ) {
         match *self.borrow() {
             NodeKind::Path(ref path) => {
-                path::render(self, path, writer, content, ctx, accumulated_transform)
+                path::render(self, path, chunk, content, ctx, accumulated_transform)
             }
             NodeKind::Group(ref group) => {
-                group::render(self, group, writer, content, ctx, accumulated_transform)
+                group::render(self, group, chunk, content, ctx, accumulated_transform)
             }
             #[cfg(feature = "image")]
-            NodeKind::Image(ref image) => image::render(image, writer, content, ctx),
+            NodeKind::Image(ref image) => image::render(image, chunk, content, ctx),
             // Texts should be converted beforehand.
             _ => {}
         }

--- a/src/render/pattern.rs
+++ b/src/render/pattern.rs
@@ -2,7 +2,7 @@ use std::ops::Mul;
 use std::rc::Rc;
 
 use pdf_writer::types::{PaintType, TilingType};
-use pdf_writer::{Content, Filter, PdfWriter};
+use pdf_writer::{Chunk, Content, Filter};
 use usvg::utils::view_box_to_transform;
 use usvg::{NodeKind, NonZeroRect, Opacity, Size, Transform, Units};
 
@@ -15,7 +15,7 @@ use crate::util::helper::TransformExt;
 pub fn create(
     pattern: Rc<usvg::Pattern>,
     parent_bbox: &NonZeroRect,
-    writer: &mut PdfWriter,
+    chunk: &mut Chunk,
     ctx: &mut Context,
     matrix: Transform,
     initial_opacity: Option<Opacity>,
@@ -75,7 +75,7 @@ pub fn create(
             group::render(
                 &pattern.root,
                 group,
-                writer,
+                chunk,
                 &mut content,
                 ctx,
                 Transform::default(),
@@ -85,7 +85,7 @@ pub fn create(
 
             let content_stream = ctx.finish_content(content);
 
-            let mut tiling_pattern = writer.tiling_pattern(pattern_ref, &content_stream);
+            let mut tiling_pattern = chunk.tiling_pattern(pattern_ref, &content_stream);
 
             if ctx.options.compress {
                 tiling_pattern.filter(Filter::FlateDecode);

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -34,7 +34,7 @@ usvg = "0.35.0"
 pdfium-render = "0.8.6"
 walkdir = "2.3.3"
 lazy_static = "1.4.0"
-pdf-writer = "0.8"
+pdf-writer = "0.9"
 image = "0.24"
 indicatif = "0.17.5"
 oxipng = { version = "8.0.0", default-features = false, features = ["filetime", "parallel", "zopfli"] }


### PR DESCRIPTION
This adapts `svg2pdf` to allow writing into `pdf-writer`'s new [`Chunk`](https://github.com/typst/pdf-writer/pull/18) type. This makes it more flexible to use. https://github.com/typst/pdf-writer/pull/18 must be merged (and possibly released) first.

This only minimal adapts the public interface. But the chunk type could maybe also be useful internally for things the `Deferrer` is used for at the moment?