### PR TITLE
Correction for the use of dpi_ratio

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,8 +393,9 @@ fn pdf_size(tree: &Tree, options: Options) -> Size {
     // If no custom viewport is defined, we use the size of the tree.
     let viewport_size = options.viewport.unwrap_or(tree.size);
     Size::from_wh(
-        viewport_size.width() * dpi_ratio(options.dpi),
-        viewport_size.height() * dpi_ratio(options.dpi),
+        // dpi_ratio is in dot per user unit so dividing by it gave user unit
+        viewport_size.width() / dpi_ratio(options.dpi),
+        viewport_size.height() / dpi_ratio(options.dpi),
     )
     .unwrap()
 }

--- a/src/util/helper.rs
+++ b/src/util/helper.rs
@@ -196,6 +196,7 @@ pub fn fit_view_box(size: Size, vb: &usvg::ViewBox) -> usvg::Size {
 }
 
 /// Calculate the scale ratio of a DPI value.
+/// Turns a DPI in a dot per user unit (1/72nd of an inch by default)
 pub fn dpi_ratio(dpi: f32) -> f32 {
     dpi / 72.0
 }


### PR DESCRIPTION
The commit is meant to fix #55 
This turns a multiplication into a division in the use of the dpi_ratio