### PR TITLE
Re-export pdf-writer from the crate root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Re-exported `pdf-writer` at the crate root (`svg2pdf::pdf_writer`), mirroring the existing `usvg` re-export, so consumers of `to_chunk` can use a version-matched `pdf-writer` without separately pinning it.
+
 ### Changed
 - Bumped resvg to v0.46, pdf-writer to v0.14, oxi-png to v10, and miniz_oxide to v0.9.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ Among the unsupported features are currently:
 mod render;
 mod util;
 
+pub use pdf_writer;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 pub use usvg;


### PR DESCRIPTION
`to_chunk` returns pdf_writer::Chunk/Ref and its doc example has callers `use pdf_writer` directly, yet the crate re-exports only usvg, not pdf-writer. 

Downstreams then have to pin a compatible pdf-writer version by hand, risking the same version-mismatch breakage that motivated re-exporting usvg (#54, which fixed #53). Re-export it so consumers stay locked to the pdf-writer version svg2pdf actually uses.