### PR TITLE
Add trees_to_pdf for multi-page output with shared fonts/profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New `trees_to_pdf` function that converts several SVG trees into a single multi-page PDF, one page per tree. Fonts and color profiles are embedded once and shared across all pages, so a multi-page document is much smaller than concatenating the output of `to_pdf` for each tree. `to_pdf` is now a thin wrapper over `trees_to_pdf`.
+- New `ConversionError::EmptyDocument` and `ConversionError::MismatchedFontDatabases` variants, returned by `trees_to_pdf` when it is given no trees, or trees created from different font databases, respectively.
+
 ### Changed
 - Bumped resvg to v0.46, pdf-writer to v0.14, oxi-png to v10, and miniz_oxide to v0.9.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,14 @@ pub enum ConversionError {
     MissingGlyphs,
     /// Converting the SVG would require too much nesting depth.
     TooMuchNesting,
+    /// No trees were provided for conversion. A PDF must contain at least one
+    /// page, so an empty document cannot be produced.
+    EmptyDocument,
+    /// Trees passed to [`trees_to_pdf`] were created from different font
+    /// databases. Fonts are keyed per database, so all trees must share one;
+    /// otherwise their glyphs could be mixed up. Only reported when text is
+    /// being embedded.
+    MismatchedFontDatabases,
     /// An unknown error occurred during the conversion. This could indicate a bug in the
     /// svg2pdf.
     UnknownError,
@@ -118,6 +126,8 @@ impl Display for ConversionError {
             Self::InvalidImage => f.write_str("An unknown type of image appears in the SVG."),
             Self::MissingGlyphs => f.write_str("A piece of text could not be displayed with any font."),
             Self::TooMuchNesting => f.write_str("The SVG's nesting depth is too high."),
+            Self::EmptyDocument => f.write_str("No SVG trees were provided; a PDF must contain at least one page."),
+            Self::MismatchedFontDatabases => f.write_str("The provided trees do not all share the same font database."),
             Self::UnknownError => f.write_str("An unknown error occurred during the conversion. This could indicate a bug in svg2pdf"),
             #[cfg(feature = "text")]
             Self::SubsetError(_) => f.write_str("An error occurred while subsetting a font."),
@@ -177,6 +187,9 @@ impl Default for ConversionOptions {
 
 /// Convert a [`usvg` tree](Tree) into a standalone PDF buffer.
 ///
+/// To convert several trees into a single multi-page PDF that embeds shared
+/// fonts and color profiles only once, use [`trees_to_pdf`].
+///
 /// ## Example
 /// The example below reads an SVG file, processes text within it, then converts
 /// it into a PDF and finally writes it back to the file system.
@@ -205,54 +218,140 @@ pub fn to_pdf(
     conversion_options: ConversionOptions,
     page_options: PageOptions,
 ) -> Result<Vec<u8>> {
-    let mut ctx = Context::new(tree, conversion_options)?;
+    trees_to_pdf(&[tree], conversion_options, page_options)
+}
+
+/// Convert several [`usvg` trees](Tree) into a single multi-page PDF buffer,
+/// with one page per tree.
+///
+/// Fonts and color profiles are accumulated across all trees and embedded only
+/// once, shared by every page. As a result the produced document is
+/// substantially smaller than concatenating the output of [`to_pdf`] for each
+/// tree, which would re-embed each font subset and ICC profile on every page.
+///
+/// Each page's size is derived from its own tree (scaled by
+/// [`PageOptions::dpi`]), so pages may differ in size.
+///
+/// When embedding text, all trees **must** be created from the same
+/// [font database](usvg::fontdb::Database) — typically by parsing them with a
+/// single [`usvg::Options`] — because fonts are keyed by their
+/// [`fontdb::ID`], which is only unique within one database. Passing trees from
+/// different databases returns [`ConversionError::MismatchedFontDatabases`]
+/// rather than silently rendering the wrong glyphs.
+///
+/// Passing an empty slice returns [`ConversionError::EmptyDocument`], because a
+/// PDF must contain at least one page. Conversely,
+/// `trees_to_pdf(&[&tree], ..)` is equivalent to `to_pdf(&tree, ..)`.
+///
+/// ## Example
+/// The example below reads two SVG files and combines them into a single
+/// two-page PDF. Any font used by both files is embedded only once.
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use svg2pdf::{ConversionOptions, PageOptions};
+///
+/// let paths = [
+///     "tests/svg/custom/integration/matplotlib/stairs.svg",
+///     "tests/svg/custom/integration/matplotlib/signals.svg",
+/// ];
+///
+/// // Parse every SVG with the same options (and thus the same font database)
+/// // so that shared fonts can be deduplicated across pages.
+/// let mut options = svg2pdf::usvg::Options::default();
+/// options.fontdb_mut().load_system_fonts();
+///
+/// let mut trees = Vec::new();
+/// for path in paths {
+///     let svg = std::fs::read_to_string(path)?;
+///     trees.push(svg2pdf::usvg::Tree::from_str(&svg, &options)?);
+/// }
+///
+/// let tree_refs = trees.iter().collect::<Vec<_>>();
+/// let pdf = svg2pdf::trees_to_pdf(
+///     &tree_refs,
+///     ConversionOptions::default(),
+///     PageOptions::default(),
+/// )
+/// .unwrap();
+/// std::fs::write("target/report.pdf", pdf)?;
+/// # Ok(()) }
+/// ```
+pub fn trees_to_pdf(
+    trees: &[&Tree],
+    conversion_options: ConversionOptions,
+    page_options: PageOptions,
+) -> Result<Vec<u8>> {
+    if trees.is_empty() {
+        return Err(ConversionError::EmptyDocument);
+    }
+
+    let mut ctx = Context::new_multi(trees, conversion_options)?;
     let mut pdf = Pdf::new();
 
     let dpi_ratio = 72.0 / page_options.dpi;
     let dpi_transform = Transform::from_scale(dpi_ratio, dpi_ratio);
-    let page_size =
-        Size::from_wh(tree.size().width() * dpi_ratio, tree.size().height() * dpi_ratio)
-            .ok_or(UnknownError)?;
 
     let catalog_ref = ctx.alloc_ref();
     let page_tree_ref = ctx.alloc_ref();
-    let page_ref = ctx.alloc_ref();
-    let content_ref = ctx.alloc_ref();
-
     pdf.catalog(catalog_ref).pages(page_tree_ref);
-    pdf.pages(page_tree_ref).count(1).kids([page_ref]);
 
-    // Generate main content
-    let mut rc = ResourceContainer::new();
-    let mut content = Content::new();
-    content.save_state_checked()?;
-    content.transform(dpi_transform.to_pdf_transform());
-    tree_to_stream(tree, &mut pdf, &mut content, &mut ctx, &mut rc)?;
-    content.restore_state();
-    let content_stream = ctx.finish_content(content);
-    let mut stream = pdf.stream(content_ref, &content_stream);
+    // Write one page per tree, all sharing the same `Context` so that its fonts
+    // and color profiles are emitted only once, in `write_global_objects` below.
+    let mut page_refs = Vec::with_capacity(trees.len());
+    for &tree in trees {
+        let page_size = Size::from_wh(
+            tree.size().width() * dpi_ratio,
+            tree.size().height() * dpi_ratio,
+        )
+        .ok_or(UnknownError)?;
 
-    if ctx.options.compress {
-        stream.filter(Filter::FlateDecode);
+        let page_ref = ctx.alloc_ref();
+        let content_ref = ctx.alloc_ref();
+        page_refs.push(page_ref);
+
+        // Each page gets a fresh resource dictionary, but the font/XObject refs
+        // it names come from the shared context, so identical resources resolve
+        // to the same objects on every page.
+        let mut rc = ResourceContainer::new();
+        let mut content = Content::new();
+        content.save_state_checked()?;
+        content.transform(dpi_transform.to_pdf_transform());
+        tree_to_stream(tree, &mut pdf, &mut content, &mut ctx, &mut rc)?;
+        content.restore_state();
+        let content_stream = ctx.finish_content(content);
+        let mut stream = pdf.stream(content_ref, &content_stream);
+
+        if ctx.options.compress {
+            stream.filter(Filter::FlateDecode);
+        }
+        stream.finish();
+
+        let mut page = pdf.page(page_ref);
+        let mut page_resources = page.resources();
+        rc.finish(&mut page_resources);
+        page_resources.finish();
+
+        page.media_box(page_size.to_non_zero_rect(0.0, 0.0).to_pdf_rect());
+        page.parent(page_tree_ref);
+        // The sRGB reference is shared across pages, so every page's transparency
+        // group points at the same ICC profile object.
+        page.group()
+            .transparency()
+            .isolated(true)
+            .knockout(false)
+            .color_space()
+            .icc_based(ctx.srgb_ref());
+        page.contents(content_ref);
+        page.finish();
     }
-    stream.finish();
 
-    let mut page = pdf.page(page_ref);
-    let mut page_resources = page.resources();
-    rc.finish(&mut page_resources);
-    page_resources.finish();
+    pdf.pages(page_tree_ref)
+        .count(page_refs.len() as i32)
+        .kids(page_refs.iter().copied());
 
-    page.media_box(page_size.to_non_zero_rect(0.0, 0.0).to_pdf_rect());
-    page.parent(page_tree_ref);
-    page.group()
-        .transparency()
-        .isolated(true)
-        .knockout(false)
-        .color_space()
-        .icc_based(ctx.srgb_ref());
-    page.contents(content_ref);
-    page.finish();
-
+    // Fonts and ICC profiles accumulated across every page are written exactly
+    // once here — the whole reason for sharing a single context.
     ctx.write_global_objects(&mut pdf)?;
 
     let document_info_id = ctx.alloc_ref();

--- a/src/util/context.rs
+++ b/src/util/context.rs
@@ -6,6 +6,7 @@ use {
     crate::render::text,
     crate::render::text::{write_font, Font},
     std::collections::HashMap,
+    std::sync::Arc,
     usvg::fontdb::ID,
 };
 
@@ -27,8 +28,20 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn new(
-        #[allow(unused_variables)] tree: &Tree,
+    pub fn new(tree: &Tree, options: ConversionOptions) -> Result<Self> {
+        Self::new_multi(&[tree], options)
+    }
+
+    /// Create a context whose accumulated font set covers *all* of the given
+    /// trees.
+    ///
+    /// Because `fill_fonts` is additive and subsetting is deferred to
+    /// [`Self::write_global_objects`], running it for every tree up front means
+    /// each font is later written as a single union subset shared by all pages.
+    /// This is what lets [`crate::trees_to_pdf`] deduplicate fonts across the
+    /// pages of a multi-page document.
+    pub fn new_multi(
+        #[allow(unused_variables)] trees: &[&Tree],
         options: ConversionOptions,
     ) -> Result<Self> {
         #[allow(unused_mut)]
@@ -43,7 +56,19 @@ impl Context {
 
         #[cfg(feature = "text")]
         if options.embed_text {
-            text::fill_fonts(tree.root(), &mut ctx, tree.fontdb().as_ref())?;
+            // Fonts are keyed by `fontdb::ID`, which is only unique within a
+            // single database. Accumulating fonts from trees backed by different
+            // databases would merge unrelated faces under colliding IDs and
+            // silently emit the wrong glyphs, so require one shared database.
+            if let Some((first, rest)) = trees.split_first() {
+                if rest.iter().any(|tree| !Arc::ptr_eq(tree.fontdb(), first.fontdb())) {
+                    return Err(crate::ConversionError::MismatchedFontDatabases);
+                }
+            }
+
+            for tree in trees {
+                text::fill_fonts(tree.root(), &mut ctx, tree.fontdb().as_ref())?;
+            }
         }
 
         Ok(ctx)

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,6 +1,7 @@
 #[rustfmt::skip]
 mod render;
 mod api;
+mod multi_page;
 
 use std::cmp::max;
 use std::fs;
@@ -40,25 +41,36 @@ static PDFIUM: Lazy<std::sync::Mutex<Pdfium>> = Lazy::new(|| {
     std::sync::Mutex::new(pdfium)
 });
 
-/// Converts a PDF into a png image.
+/// Converts a PDF into a png image, rendering its first page.
 pub fn render_pdf(pdf: &[u8]) -> RgbaImage {
+    render_pdf_page(pdf, 0)
+}
+
+/// Renders a specific (0-indexed) page of a PDF into a png image.
+pub fn render_pdf_page(pdf: &[u8], page_index: u16) -> RgbaImage {
     let pdfium = PDFIUM.lock().unwrap();
-    let document = pdfium.load_pdf_from_byte_slice(pdf, None);
+    let document = pdfium.load_pdf_from_byte_slice(pdf, None).unwrap();
 
     let render_config = PdfRenderConfig::new()
         .clear_before_rendering(true)
         .set_clear_color(PdfColor::new(255, 255, 255, 0));
 
     let result = document
-        .unwrap()
         .pages()
-        .first()
+        .get(page_index)
         .unwrap()
         .render_with_config(&render_config)
         .unwrap()
         .as_image()
         .into_rgba8();
     result
+}
+
+/// Returns the number of pages pdfium finds in a PDF.
+pub fn pdf_page_count(pdf: &[u8]) -> usize {
+    let pdfium = PDFIUM.lock().unwrap();
+    let document = pdfium.load_pdf_from_byte_slice(pdf, None).unwrap();
+    document.pages().len() as usize
 }
 
 /// Converts an SVG string into a usvg Tree

--- a/tests/src/multi_page.rs
+++ b/tests/src/multi_page.rs
@@ -1,0 +1,243 @@
+//! Tests for [`svg2pdf::trees_to_pdf`], the multi-page conversion entry point.
+//!
+//! These focus on behaviour unique to the multi-page path: page count, per-page
+//! sizing, and — the whole point of the feature — deduplication of fonts and
+//! color profiles across pages. The single-tree path is exercised
+//! comprehensively by the visual regression suite in `render.rs`, since
+//! `to_pdf` now delegates to `trees_to_pdf`.
+
+// These helpers and imports are only referenced from `#[test]` functions, which
+// are absent from the plain (non-test) `cargo build --all` that CI runs with
+// `-Dwarnings`. Allow them so that build stays warning-free, as `api.rs` and
+// `render.rs` do.
+#![allow(dead_code, unused_imports)]
+
+use {
+    crate::{pdf_page_count, read_svg, render_pdf_page},
+    image::RgbaImage,
+    std::sync::Arc,
+    svg2pdf::{ConversionError, ConversionOptions, PageOptions},
+};
+
+/// Builds a minimal SVG string with a single line of text in a given font.
+fn text_svg(width: u32, height: u32, font_family: &str, text: &str) -> String {
+    format!(
+        r#"<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">
+            <rect x="0" y="0" width="{width}" height="{height}" fill="white"/>
+            <text x="10" y="40" font-family="{font_family}" font-size="24" fill="black">{text}</text>
+        </svg>"#
+    )
+}
+
+/// Counts non-overlapping byte occurrences of `needle` in `haystack`.
+fn count(haystack: &[u8], needle: &[u8]) -> usize {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return 0;
+    }
+    haystack.windows(needle.len()).filter(|w| *w == needle).count()
+}
+
+/// Extracts every `/MediaBox [..]` entry from a PDF as raw byte slices.
+fn media_boxes(pdf: &[u8]) -> Vec<Vec<u8>> {
+    const KEY: &[u8] = b"/MediaBox";
+    let mut boxes = Vec::new();
+    let mut offset = 0;
+    while let Some(rel) = pdf[offset..].windows(KEY.len()).position(|w| w == KEY) {
+        let start = offset + rel;
+        let Some(close) = pdf[start..].iter().position(|&b| b == b']') else { break };
+        boxes.push(pdf[start..=start + close].to_vec());
+        offset = start + close + 1;
+    }
+    boxes
+}
+
+/// Whether a rendered page contains any drawn (non-transparent) pixel. The
+/// pdfium render config clears to transparent white, so drawn content shows up
+/// as a pixel with a non-zero alpha channel.
+fn has_content(image: &RgbaImage) -> bool {
+    image.pixels().any(|p| p.0[3] != 0)
+}
+
+#[test]
+fn two_trees_produce_a_two_page_pdf() {
+    let a = read_svg(&text_svg(100, 100, "Noto Sans", "Hello"));
+    let b = read_svg(&text_svg(120, 100, "Noto Sans", "World"));
+
+    let pdf = svg2pdf::trees_to_pdf(
+        &[&a, &b],
+        ConversionOptions::default(),
+        PageOptions::default(),
+    )
+    .unwrap();
+
+    // The page tree declares two kids and there are two page objects.
+    assert_eq!(count(&pdf, b"/Count 2"), 1);
+    assert_eq!(media_boxes(&pdf).len(), 2);
+    // pdfium agrees it is a valid two-page document.
+    assert_eq!(pdf_page_count(&pdf), 2);
+}
+
+#[test]
+fn fonts_are_shared_across_pages() {
+    // Both pages use the same font but different glyphs, so a single union
+    // subset must serve the whole document.
+    let a = read_svg(&text_svg(200, 100, "Noto Sans", "Hello"));
+    let b = read_svg(&text_svg(200, 100, "Noto Sans", "World Foo"));
+
+    let combined = svg2pdf::trees_to_pdf(
+        &[&a, &b],
+        ConversionOptions::default(),
+        PageOptions::default(),
+    )
+    .unwrap();
+
+    // Exactly one embedded font program and one font descriptor for the whole
+    // document, not one per page.
+    assert_eq!(count(&combined, b"/FontFile"), 1);
+    assert_eq!(count(&combined, b"/Type /FontDescriptor"), 1);
+
+    // Sanity check that stapling the single-page PDFs together really would
+    // duplicate the font: each standalone PDF embeds its own copy.
+    let single_a =
+        svg2pdf::to_pdf(&a, ConversionOptions::default(), PageOptions::default())
+            .unwrap();
+    let single_b =
+        svg2pdf::to_pdf(&b, ConversionOptions::default(), PageOptions::default())
+            .unwrap();
+    assert_eq!(count(&single_a, b"/FontFile") + count(&single_b, b"/FontFile"), 2);
+
+    // And the shared document is smaller than the two standalone PDFs combined.
+    assert!(combined.len() < single_a.len() + single_b.len());
+}
+
+#[test]
+fn color_profile_is_shared_across_pages() {
+    let a = read_svg(&text_svg(100, 100, "Noto Sans", "Hello"));
+    let b = read_svg(&text_svg(100, 100, "Noto Sans", "World"));
+
+    let combined = svg2pdf::trees_to_pdf(
+        &[&a, &b],
+        ConversionOptions::default(),
+        PageOptions::default(),
+    )
+    .unwrap();
+
+    // A single sRGB ICC profile object serves both pages. The profile stream is
+    // the only 3-channel ICC object (`/N 3`) in the document.
+    assert_eq!(count(&combined, b"/N 3"), 1);
+    assert_eq!(count(&combined, b"/Range [0 1 0 1 0 1]"), 1);
+
+    // Each standalone PDF carries its own copy, so stapling would double it.
+    let single =
+        svg2pdf::to_pdf(&a, ConversionOptions::default(), PageOptions::default())
+            .unwrap();
+    assert_eq!(count(&single, b"/N 3"), 1);
+}
+
+#[test]
+fn pages_can_have_different_sizes() {
+    let a = read_svg(&text_svg(100, 100, "Noto Sans", "A"));
+    let b = read_svg(&text_svg(200, 150, "Noto Sans", "B"));
+
+    let pdf = svg2pdf::trees_to_pdf(
+        &[&a, &b],
+        ConversionOptions::default(),
+        PageOptions::default(),
+    )
+    .unwrap();
+
+    let boxes = media_boxes(&pdf);
+    assert_eq!(boxes.len(), 2);
+    assert_ne!(
+        boxes[0], boxes[1],
+        "pages built from different-sized trees should differ"
+    );
+}
+
+#[test]
+fn empty_slice_is_an_error() {
+    let result =
+        svg2pdf::trees_to_pdf(&[], ConversionOptions::default(), PageOptions::default());
+    assert!(matches!(result, Err(ConversionError::EmptyDocument)));
+}
+
+#[test]
+fn single_tree_produces_one_renderable_page() {
+    let tree = read_svg(&text_svg(100, 100, "Noto Sans", "Hi"));
+
+    let pdf = svg2pdf::trees_to_pdf(
+        &[&tree],
+        ConversionOptions::default(),
+        PageOptions::default(),
+    )
+    .unwrap();
+
+    assert_eq!(pdf_page_count(&pdf), 1);
+    assert!(has_content(&render_pdf_page(&pdf, 0)));
+}
+
+#[test]
+fn both_pages_render() {
+    let a = read_svg(&text_svg(100, 100, "Noto Sans", "Page one"));
+    let b = read_svg(&text_svg(100, 100, "Noto Sans", "Page two"));
+
+    let pdf = svg2pdf::trees_to_pdf(
+        &[&a, &b],
+        ConversionOptions::default(),
+        PageOptions::default(),
+    )
+    .unwrap();
+
+    assert!(has_content(&render_pdf_page(&pdf, 0)));
+    assert!(has_content(&render_pdf_page(&pdf, 1)));
+}
+
+#[test]
+fn text_to_paths_mode_embeds_no_fonts() {
+    let options = ConversionOptions { embed_text: false, ..ConversionOptions::default() };
+    let a = read_svg(&text_svg(100, 100, "Noto Sans", "Hello"));
+    let b = read_svg(&text_svg(100, 100, "Noto Sans", "World"));
+
+    let pdf = svg2pdf::trees_to_pdf(&[&a, &b], options, PageOptions::default()).unwrap();
+
+    assert_eq!(pdf_page_count(&pdf), 2);
+    // With text flattened to paths, no font program is embedded at all.
+    assert_eq!(count(&pdf, b"/FontFile"), 0);
+}
+
+#[test]
+fn pdfa_mode_succeeds() {
+    let options = ConversionOptions { pdfa: true, ..ConversionOptions::default() };
+    let a = read_svg(&text_svg(100, 100, "Noto Sans", "Hello"));
+    let b = read_svg(&text_svg(100, 100, "Noto Sans", "World"));
+
+    let pdf = svg2pdf::trees_to_pdf(&[&a, &b], options, PageOptions::default()).unwrap();
+
+    assert_eq!(pdf_page_count(&pdf), 2);
+    // Fonts are still shared across pages in PDF/A mode.
+    assert_eq!(count(&pdf, b"/FontFile"), 1);
+}
+
+#[test]
+fn trees_from_different_font_databases_error() {
+    // Each tree is parsed with its own font database, violating the
+    // shared-database invariant that font dedup relies on. `fontdb::ID`s are
+    // only unique within one database, so this must be rejected rather than
+    // silently rendering the wrong glyphs.
+    let separate_tree = |text: &str| {
+        let mut db = fontdb::Database::new();
+        db.load_fonts_dir("fonts");
+        db.set_sans_serif_family("Noto Sans");
+        let options = usvg::Options { fontdb: Arc::new(db), ..usvg::Options::default() };
+        usvg::Tree::from_str(&text_svg(100, 100, "Noto Sans", text), &options).unwrap()
+    };
+    let a = separate_tree("Hello");
+    let b = separate_tree("World");
+
+    let result = svg2pdf::trees_to_pdf(
+        &[&a, &b],
+        ConversionOptions::default(),
+        PageOptions::default(),
+    );
+    assert!(matches!(result, Err(ConversionError::MismatchedFontDatabases)));
+}


### PR DESCRIPTION
Implements #100.

This is my first non-trivial PR into this repo.  I should flag that it is heavily AI assisted, but that I've also spent non-trivial amounts of time guiding and reviewing, and this is not a blind AI submission.  I'm very open to feedback, so please let me know if there are changes you'd like to see to the PR.

It adds `trees_to_pdf`, which converts several `usvg::Tree`s into one multi-page PDF — one page per tree — over a single shared `Context`, so each font subset and ICC color profile is embedded once for the whole document instead of once per page. As covered in the issue, it needed no new subsetting logic; `to_pdf` is now a one-line wrapper over it.

A few things worth calling out:

- **Font database constraint.** Because fonts are keyed by `fontdb::ID` (which isn't stable across `fontdb::Database` instances), all trees have to be parsed against the same font database. Passing trees from different databases returns the new `ConversionError::MismatchedFontDatabases` rather than silently rendering the wrong glyphs. An empty slice returns `ConversionError::EmptyDocument`.
- **Slightly breaking.** Those are two new `ConversionError` variants, so downstream exhaustive matches would need updating — flagging it for the version bump.
- **Scope.** Sharing covers fonts and ICC profiles; repeated images/gradients/patterns across pages aren't deduplicated yet. There's also a pre-existing per-text-node `ctx.fonts.clone()` that gets a bit pricier with a shared context — I left it alone to keep this focused, but happy to follow up.

Tests in `tests/src/multi_page.rs` cover the two-page case, font/ICC dedup, per-page sizing, `embed_text = false`, `pdfa`, the empty and mismatched-database errors, and that both pages actually render through pdfium. CHANGELOG is updated.